### PR TITLE
🔧 config(memorix): 移除高频噪音 hooks 配置，仅保留会话生命周期事件

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,17 +12,6 @@
 				]
 			}
 		],
-		"PostToolUse": [
-			{
-				"hooks": [
-					{
-						"type": "command",
-						"command": "memorix.cmd hook",
-						"timeout": 10
-					}
-				]
-			}
-		],
 		"UserPromptSubmit": [
 			{
 				"hooks": [


### PR DESCRIPTION
## Summary

- 移除 Memorix hooks 中的高频噪音触发器（PostToolUse、AfterTool、afterFileEdit、afterMCPExecution、beforeShellExecution、post_write_code、post_run_command、post_mcp_tool_use）
- 仅保留会话生命周期事件 hooks（SessionStart、UserPromptSubmit/beforeSubmitPrompt、PreCompact、Stop）
- 涉及 .claude/settings.local.json、.cursor/hooks.json、.gemini/settings.json

## Why

这些高频 hooks 每次工具调用/文件编辑/命令执行都会触发 Memorix 记录，产生大量无意义的噪音记忆（占比超 63%），严重影响记忆检索质量。

## Verification

- 确认保留的 hooks 仍能在会话开始、用户提交、压缩前、会话结束时正常记录
- 确认移除的 hooks 不再产生每次操作的噪音记录