### PR TITLE
config: 统一添加 package.json 的 author 字段

### DIFF
--- a/docs/docs-01-star/package.json
+++ b/docs/docs-01-star/package.json
@@ -13,7 +13,11 @@
 		"docs:preview": "vitepress preview docs"
 	},
 	"keywords": [],
-	"author": "ruan-cat",
+	"author": {
+		"name": "ruan-cat",
+		"email": "1219043956@qq.com",
+		"url": "https://github.com/ruan-cat"
+	},
 	"license": "MIT",
 	"devDependencies": {
 		"@ruan-cat/vitepress-preset-config": "^3.1.2",

--- a/docs/my-pull-requests/package.json
+++ b/docs/my-pull-requests/package.json
@@ -3,7 +3,11 @@
 	"type": "module",
 	"private": true,
 	"version": "0.0.1",
-	"author": "阮喵喵",
+	"author": {
+		"name": "ruan-cat",
+		"email": "1219043956@qq.com",
+		"url": "https://github.com/ruan-cat"
+	},
 	"license": "MIT",
 	"description": "阮喵喵在github的全部commit和pr汇总站点，以 atinux/my-pull-requests 项目为模板制作。",
 	"scripts": {

--- a/docs/rpgmv-dev-notes/package.json
+++ b/docs/rpgmv-dev-notes/package.json
@@ -2,7 +2,11 @@
 	"name": "@ruan-cat-docs/rpgmv-dev-notes",
 	"private": true,
 	"version": "1.0.0",
-	"author": "阮喵喵",
+	"author": {
+		"name": "ruan-cat",
+		"email": "1219043956@qq.com",
+		"url": "https://github.com/ruan-cat"
+	},
 	"license": "MIT",
 	"description": "阮喵喵的rmmv开发笔记",
 	"scripts": {

--- a/docs/ruan-cat-notes/package.json
+++ b/docs/ruan-cat-notes/package.json
@@ -2,7 +2,11 @@
 	"name": "@ruan-cat-docs/notes",
 	"private": true,
 	"version": "1.0.0",
-	"author": "阮喵喵",
+	"author": {
+		"name": "ruan-cat",
+		"email": "1219043956@qq.com",
+		"url": "https://github.com/ruan-cat"
+	},
 	"license": "MIT",
 	"description": "阮喵喵自己的笔记。",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
 		"vercel": "44.2.8",
 		"vite": "^7.0.0",
 		"vitest": "^3.2.4"
+	},
+	"author": {
+		"name": "ruan-cat",
+		"email": "1219043956@qq.com",
+		"url": "https://github.com/ruan-cat"
 	}
 }


### PR DESCRIPTION
## Summary

- 为根目录及所有子包的 package.json 统一添加/覆盖 author 字段
- author 信息统一为：`{ "name": "ruan-cat", "email": "1219043956@qq.com", "url": "https://github.com/ruan-cat" }`

## Why

规范化包元数据，确保所有包的作者信息一致且完整。

## Verification

- 检查所有 package.json 中 author 字段是否正确设置