### PR TITLE
ci(workflows): 统一升级 setup-node 至 Node.js 24.18.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: 安装node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.14.0
+          node-version: 24.18.0
           cache: pnpm
 
       - name: 检查版本

--- a/.github/workflows/vercel-deploy-tool.yaml
+++ b/.github/workflows/vercel-deploy-tool.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: 安装node
         uses: actions/setup-node@v6
         with:
-          node-version: 20.15.1
+          node-version: 24.18.0
           cache: pnpm
 
       - name: 检查版本


### PR DESCRIPTION
## 改动说明

将本仓库 GitHub Actions 工作流中的 `actions/setup-node` 步骤统一升级到 Node.js `24.18.0`。

## 改动范围

- 扫描 `.github/workflows/*.yml` 和 `.github/workflows/*.yaml`
- 更新所有 `setup-node` 步骤的 `node-version` 为 `24.18.0`
- 保持 `actions/setup-node@v6`、`cache: pnpm` 不变
- release 工作流保留 `registry-url` 配置

## 验证方式

- 本地 `grep` 确认所有 `node-version` 已更新为 `24.18.0`
- 提交后通过 GitHub Actions 运行验证
